### PR TITLE
Adding ContentType object and index files

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,11 @@
   },
   "require-dev": {
     "pestphp/pest": "^1.0",
-    "friendsofphp/php-cs-fixer": "^3.3.0"
+    "friendsofphp/php-cs-fixer": "^3.16"
+  },
+  "scripts": {
+    "test" : ["pest"],
+    "csfix": ["php-cs-fixer fix"]
   },
   "config": {
     "allow-plugins": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "73fae3eef671d4f98065ab5fadfca671",
+    "content-hash": "11344e6afee475570ba13217b4421d56",
     "packages": [
         {
             "name": "dflydev/dot-access-data",
@@ -1858,23 +1858,23 @@
         },
         {
             "name": "pestphp/pest",
-            "version": "v1.22.6",
+            "version": "v1.23.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/pestphp/pest.git",
-                "reference": "9f6a88232733f9d1e33f49531340f447bd255c9e"
+                "reference": "061c9de301531e500a8157b476a5899361e60068"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/pestphp/pest/zipball/9f6a88232733f9d1e33f49531340f447bd255c9e",
-                "reference": "9f6a88232733f9d1e33f49531340f447bd255c9e",
+                "url": "https://api.github.com/repos/pestphp/pest/zipball/061c9de301531e500a8157b476a5899361e60068",
+                "reference": "061c9de301531e500a8157b476a5899361e60068",
                 "shasum": ""
             },
             "require": {
                 "nunomaduro/collision": "^5.11.0|^6.4.0",
                 "pestphp/pest-plugin": "^1.1.0",
                 "php": "^7.3 || ^8.0",
-                "phpunit/phpunit": "^9.6.5"
+                "phpunit/phpunit": "^9.6.7"
             },
             "require-dev": {
                 "illuminate/console": "^8.83.27",
@@ -1935,7 +1935,7 @@
             ],
             "support": {
                 "issues": "https://github.com/pestphp/pest/issues",
-                "source": "https://github.com/pestphp/pest/tree/v1.22.6"
+                "source": "https://github.com/pestphp/pest/tree/v1.23.0"
             },
             "funding": [
                 {
@@ -1943,27 +1943,11 @@
                     "type": "custom"
                 },
                 {
-                    "url": "https://github.com/lukeraymonddowning",
-                    "type": "github"
-                },
-                {
                     "url": "https://github.com/nunomaduro",
                     "type": "github"
-                },
-                {
-                    "url": "https://github.com/olivernybroe",
-                    "type": "github"
-                },
-                {
-                    "url": "https://github.com/owenvoke",
-                    "type": "github"
-                },
-                {
-                    "url": "https://www.patreon.com/nunomaduro",
-                    "type": "patreon"
                 }
             ],
-            "time": "2023-03-17T23:24:14+00:00"
+            "time": "2023-04-19T20:10:22+00:00"
         },
         {
             "name": "pestphp/pest-plugin",
@@ -2468,16 +2452,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "9.6.6",
+            "version": "9.6.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "b65d59a059d3004a040c16a82e07bbdf6cfdd115"
+                "reference": "c993f0d3b0489ffc42ee2fe0bd645af1538a63b2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/b65d59a059d3004a040c16a82e07bbdf6cfdd115",
-                "reference": "b65d59a059d3004a040c16a82e07bbdf6cfdd115",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/c993f0d3b0489ffc42ee2fe0bd645af1538a63b2",
+                "reference": "c993f0d3b0489ffc42ee2fe0bd645af1538a63b2",
                 "shasum": ""
             },
             "require": {
@@ -2551,7 +2535,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
                 "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.6.6"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.6.7"
             },
             "funding": [
                 {
@@ -2567,7 +2551,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-03-27T11:43:46+00:00"
+            "time": "2023-04-14T08:58:40+00:00"
         },
         {
             "name": "psr/cache",

--- a/src/ContentType.php
+++ b/src/ContentType.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Librarian;
+
+use Parsed\ContentParser;
+
+class ContentType
+{
+    public string $slug;
+    public string $contentDir;
+    public string $title;
+    public string $description;
+    public string $index;
+
+    public function __toString(): string
+    {
+        return $this->title;
+    }
+
+    /**
+     * @throws Exception\ContentNotFoundException
+     */
+    public function __construct(string $slug, string $contentDir)
+    {
+        $this->slug = $slug;
+        $this->contentDir = $contentDir;
+        $this->loadMetadata();
+    }
+
+    /**
+     * @throws Exception\ContentNotFoundException
+     */
+    public function loadMetadata(): void
+    {
+        if (is_file($this->contentDir . '/' . $this->slug . '/_index')) {
+            $metadata = new Content();
+            $metadata->load($this->contentDir . '/' . $this->slug . '/_index');
+            $metadata->parse(new ContentParser());
+            $this->title = $metadata->frontMatterGet('title') ?? ucfirst($this->slug);
+            $this->description = $metadata->frontMatterGet('description') ?? "";
+            $this->index = $metadata->frontMatterGet('index') ?? 10;
+        }
+    }
+}

--- a/src/Provider/ContentServiceProvider.php
+++ b/src/Provider/ContentServiceProvider.php
@@ -4,6 +4,7 @@ namespace Librarian\Provider;
 
 use Librarian\Content;
 use Librarian\ContentCollection;
+use Librarian\ContentType;
 use Librarian\Exception\ContentNotFoundException;
 use Minicli\App;
 use Minicli\ServiceInterface;
@@ -213,27 +214,25 @@ class ContentServiceProvider implements ServiceInterface
         return null;
     }
 
-    /**
-     * @return array
-     */
     public function getContentTypes(): array
     {
-        $content_types = [];
-        foreach (glob($this->data_path . '/*') as $route) {
-            $content_types[] = basename($route);
+        $contentTypes = [];
+        $order = [];
+        foreach (glob($this->data_path . '/*', GLOB_ONLYDIR) as $route) {
+            $content = new ContentType(basename($route), $this->data_path);
+            $contentTypes[$content->slug] = $content;
+            $order[$content->slug] = $content->index;
         }
 
-        return $content_types;
+        asort($order, SORT_NUMERIC);
+        $orderedContent = [];
+        foreach ($order as $slug => $index) {
+            $orderedContent[] = $contentTypes[$slug];
+        }
+
+        return $orderedContent;
     }
 
-    /**
-     * @param string $route
-     * @param int $start
-     * @param int $limit
-     * @param bool $parse_markdown
-     * @param string $orderBy
-     * @return ContentCollection
-     */
     public function fetchFrom(string $route, int $start = 0, int $limit = 20, bool $parse_markdown = false, string $orderBy = 'desc'): ?ContentCollection
     {
         $feed = [];

--- a/tests/Feature/ContentCollectionTest.php
+++ b/tests/Feature/ContentCollectionTest.php
@@ -20,7 +20,7 @@ it('loads content from data path', function () {
     $posts = $app->content->fetchAll();
     expect($posts)->toBeInstanceOf(ContentCollection::class);
 
-    expect($posts->total())->toEqual(3);
+    expect($posts->total())->toEqual(5);
 });
 
 it('loads content in alphabetical (asc) order', function () {

--- a/tests/Feature/ContentTest.php
+++ b/tests/Feature/ContentTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use Librarian\ContentType;
 use Minicli\App;
 use Librarian\Provider\ContentServiceProvider;
 use Librarian\Provider\LibrarianServiceProvider;
@@ -32,24 +33,25 @@ it('sets up LibrarianServiceProvider within Minicli App', function () {
 
 it('loads content from request and parses front matter', function () {
     $content = $this->app->content->fetch('posts/test0');
-    expect($content->frontMatterGet('title'))->toEqual("Devo Produzir Conteúdo em Português ou Inglês?");
-    expect($content->body_markdown)->toBeString();
+    expect($content->frontMatterGet('title'))->toEqual("Devo Produzir Conteúdo em Português ou Inglês?")
+        ->and($content->body_markdown)->toBeString();
 });
 
 it('loads the full list of content when no limit is passed', function () {
     $content = $this->app->content->fetchAll(0, 0);
-    expect($content)->toBeInstanceOf(ContentCollection::class);
-    expect($content->total())->toBeGreaterThan(2);
+    expect($content)->toBeInstanceOf(ContentCollection::class)
+        ->and($content->total())->toBeGreaterThan(2);
 });
 
 it('loads tag list', function () {
     $tags = $this->app->content->fetchTagList(false);
-    expect($tags)->toBeArray();
-    expect(count($tags))->toBeGreaterThan(2);
+    expect($tags)->toBeArray()
+        ->and(count($tags))->toBeGreaterThan(2);
 });
 
-it('loads content types', function () {
+it('loads content types respecting index order', function () {
     $types = $this->app->content->getContentTypes();
-
-    expect($types[0])->toEqual('posts');
+    $ctype = $types[0];
+    expect($ctype)->toBeInstanceOf(ContentType::class)
+        ->and($ctype->title)->toEqual("Blog Posts");
 });

--- a/tests/resources/docs/_index
+++ b/tests/resources/docs/_index
@@ -1,0 +1,5 @@
+---
+title: Docs
+description: Docs section
+index: 100
+---

--- a/tests/resources/docs/test0.md
+++ b/tests/resources/docs/test0.md
@@ -1,0 +1,26 @@
+---
+title: Devo Produzir Conteúdo em Português ou Inglês?
+published: true
+description:
+tags: pt_br, discuss, test
+---
+
+Tudo começou com um tweet criticando brasileiros "sem relevância no exterior" que compartilham coisas em inglês.
+
+Como alguém que produz conteúdo técnico gratuitamente na Internet há mais de uma década, e que hoje trabalha profissionalmente com isso (em inglês), seria muita hipocrisia chegar para quem está começando  na carreira e  recomendar que produza conteúdo exclusivamente em português. Seria muito injusto chegar pra a Érika de 2012, que estava começando a expandir os horizontes e sair da zona de comforto pra produzir conteúdo em inglês, dizer pra ela que isso era egoísta, e que ela deveria continuar escrevendo em português. Para o bem de quem? De uma comunidade local? E a minha carreira? Conteúdo é portfólio tanto quanto código.
+
+No contexto atual, com as questões acerca de open source e de como as empresas se beneficiam do trabalho voluntário de milhares de desenvolvedores, essa discussão é muito relevante. Existe uma bandeira genérica de "sharing is caring", algo que pode ser traduzido como "compartilhar é se importar". Será que precisamos mesmo de mais tanto conteúdo, será que esse conteúdo está chegando às pessoas que precisam dele? Será que é só publicar em português e pronto?
+
+Todas essas questões são importantes, porém essa é mais uma situação onde, debaixo de uma bandeira de suposta inclusão, alguém tenta ditar ou regular quem pode e quem não pode participar de um certo grupo. É o famoso *gatekeeping*.
+
+Produzir conteúdo de qualidade é muito caro. Leva tempo e dedicação. A audiência importa, é preciso tornar viável para quem produz de graça. Vamos ser realistas: traduzir é mais eficiente do que produzir conteúdo original em português, é escalável para outras línguas e como atividade pode ser delegada mais facilmente.
+
+Enfim:
+
+Para você que produz conteúdo gratuito, parabéns, qualquer que seja o idioma. Se puder traduzir algumas coisas, ou escrever em português algumas vezes, a comunidade agradece. Mas se não puder agora, também entendemos, cada pessoa tem seu tempo 😘
+
+Ah, tem mais isso aqui:
+
+{% twitter 1195716056100298759 %}
+
+Até a próxima, talvez em português, talvez em inglês... 😉

--- a/tests/resources/docs/test1.md
+++ b/tests/resources/docs/test1.md
@@ -1,0 +1,8 @@
+---
+title: Testing Markdown Front Matter
+description: Test Description
+custom: My Custom info
+tags: test, librarian
+---
+
+## Testing

--- a/tests/resources/posts/_index
+++ b/tests/resources/posts/_index
@@ -1,0 +1,5 @@
+---
+title: Blog Posts
+description: Blog posts section
+index: 1;
+---


### PR DESCRIPTION
This PR solves [this issue](https://github.com/librarianphp/librarian/issues/21), implementing an index metadata file to sort content types. Relevant for building menus and navigation.

Tried to keep backwards compatibility by providing a _toString method on the ContentType object, so if you loop through it still works as string.