### PR TITLE
Implement ordering by index for posts

### DIFF
--- a/src/Provider/ContentServiceProvider.php
+++ b/src/Provider/ContentServiceProvider.php
@@ -266,6 +266,21 @@ class ContentServiceProvider implements ServiceInterface
             return (strtolower($content1->slug) < strtolower($content2->slug)) ? -1 : 1;
         });
 
+        if ($orderBy === 'index') {
+            $order = [];
+            $contentCollection = [];
+            /** @var Content $item */
+            foreach ($content as $item) {
+                $order[$item->slug] = $item->frontMatterGet('index') ?? 100;
+                $contentCollection[$item->slug] = $item;
+            }
+            asort($order, SORT_NUMERIC);
+            $content = [];
+            foreach ($order as $slug => $index) {
+                $content[] = $contentCollection[$slug];
+            }
+        }
+
         if ($orderBy === 'desc') {
             $content = array_reverse($content);
         }

--- a/tests/Feature/ContentCollectionTest.php
+++ b/tests/Feature/ContentCollectionTest.php
@@ -18,12 +18,12 @@ it('loads content from data path', function () {
     $app->addService('content', new ContentServiceProvider());
 
     $posts = $app->content->fetchAll();
-    expect($posts)->toBeInstanceOf(ContentCollection::class);
+    expect($posts)->toBeInstanceOf(ContentCollection::class)
+        ->and($posts->total())->toEqual(5);
 
-    expect($posts->total())->toEqual(5);
 });
 
-it('loads content in alphabetical (asc) order', function () {
+it('orders content in alphabetical (asc) order', function () {
     $app = new App($this->config);
     $app->addService('content', new ContentServiceProvider());
 
@@ -32,7 +32,7 @@ it('loads content in alphabetical (asc) order', function () {
     expect($posts->current()->frontMatterGet('title'))->toEqual("Devo Produzir Conteúdo em Português ou Inglês?");
 });
 
-it('loads content in alphabetical (desc) order', function () {
+it('orders content in alphabetical (desc) order', function () {
     $app = new App($this->config);
     $app->addService('content', new ContentServiceProvider());
 
@@ -41,13 +41,22 @@ it('loads content in alphabetical (desc) order', function () {
     expect($posts->current()->frontMatterGet('title'))->toEqual("Second Test - Testing Markdown Front Matter");
 });
 
+it('orders content based on front matter index (index)', function () {
+    $app = new App($this->config);
+    $app->addService('content', new ContentServiceProvider());
+
+    $posts = $app->content->fetchFrom('posts', 0, 10, false, 'index');
+
+    expect($posts->current()->frontMatterGet('title'))->toEqual("Testing Markdown Front Matter");
+});
+
 it('parses the markdown content', function () {
     $app = new App($this->config);
     $app->addService('content', new ContentServiceProvider());
 
     $posts = $app->content->fetchAll(0, 10, true);
 
-    expect($posts->current()->frontMatterGet('title'))->toEqual("Second Test - Testing Markdown Front Matter");
-    expect($posts->current()->getSlug())->toEqual("test2");
-    expect($posts->current()->body_html)->toEqual("<h2>Testing</h2>\n");
+    expect($posts->current()->frontMatterGet('title'))->toEqual("Second Test - Testing Markdown Front Matter")
+        ->and($posts->current()->getSlug())->toEqual("test2")
+        ->and($posts->current()->body_html)->toEqual("<h2>Testing</h2>\n");
 });

--- a/tests/resources/posts/_index
+++ b/tests/resources/posts/_index
@@ -1,5 +1,5 @@
 ---
 title: Blog Posts
 description: Blog posts section
-index: 1;
+index: 1
 ---

--- a/tests/resources/posts/test0.md
+++ b/tests/resources/posts/test0.md
@@ -3,6 +3,7 @@ title: Devo Produzir Conteúdo em Português ou Inglês?
 published: true
 description:
 tags: pt_br, discuss, test
+index: 100
 ---
 
 Tudo começou com um tweet criticando brasileiros "sem relevância no exterior" que compartilham coisas em inglês.

--- a/tests/resources/posts/test1.md
+++ b/tests/resources/posts/test1.md
@@ -3,6 +3,7 @@ title: Testing Markdown Front Matter
 description: Test Description
 custom: My Custom info
 tags: test, librarian
+index: 1
 ---
 
 ## Testing

--- a/tests/resources/posts/test2.md
+++ b/tests/resources/posts/test2.md
@@ -3,6 +3,7 @@ title: Second Test - Testing Markdown Front Matter
 description: Test 2 Description
 custom: My Custom info
 tags: test, librarian
+index: 80
 ---
 
 ## Testing


### PR DESCRIPTION
Addressing https://github.com/librarianphp/librarian/issues/23 . This is relevant for docs sites that need a custom table of contents on the sidebar.