### PR TITLE
Injecting content type in ContentServiceProvider

### DIFF
--- a/src/Content.php
+++ b/src/Content.php
@@ -18,8 +18,11 @@ class Content extends Parsed
     /** @var string Content Slug */
     public string $slug;
 
-    /** @var string Route for this Content */
+    /** @var string Route */
     public string $route;
+
+    /** @var ContentType Content Type */
+    public ContentType $contentType;
 
     /** @var string Link to this content */
     public string $link;
@@ -29,13 +32,14 @@ class Content extends Parsed
 
     /**
      * Sets content type / route
-     * @param string $route
+     * @param ContentType $contentType
      */
-    public function setRoute($route)
+    public function setContentType(ContentType $contentType): void
     {
-        $this->route = $route;
+        $this->contentType = $contentType;
+        $this->route = $contentType->slug;
     }
-
+    
     /**
      * @return string
      */

--- a/src/ContentCollection.php
+++ b/src/ContentCollection.php
@@ -43,7 +43,7 @@ class ContentCollection implements Iterator
         ++$this->current_position;
     }
 
-    public function key(): mixed
+    public function key(): int
     {
         return $this->current_position;
     }

--- a/src/Provider/ContentServiceProvider.php
+++ b/src/Provider/ContentServiceProvider.php
@@ -86,6 +86,7 @@ class ContentServiceProvider implements ServiceInterface
      * @param bool $parse_markdown
      * @param string $orderBy
      * @return ContentCollection
+     * @throws ContentNotFoundException
      */
     public function fetchAll(int $start = 0, int $limit = 20, bool $parse_markdown = false, string $orderBy = 'desc'): ContentCollection
     {
@@ -121,6 +122,7 @@ class ContentServiceProvider implements ServiceInterface
     /**
      * @param int $per_page
      * @return int
+     * @throws ContentNotFoundException
      */
     public function fetchTotalPages(int $per_page = 20): int
     {
@@ -153,6 +155,7 @@ class ContentServiceProvider implements ServiceInterface
 
     /**
      * @return array|mixed
+     * @throws ContentNotFoundException
      */
     public function fetchTagList(bool $cached = true): ?array
     {
@@ -239,16 +242,23 @@ class ContentServiceProvider implements ServiceInterface
         return $orderedContent;
     }
 
-    public function fetchFrom(string $route, int $start = 0, int $limit = 20, bool $parse_markdown = false, string $orderBy = 'desc'): ?ContentCollection
+    /**
+     * @throws ContentNotFoundException
+     */
+    public function getContentType(string $contentType): ContentType
+    {
+        return new ContentType($contentType, $this->data_path);
+    }
+    public function fetchFrom(ContentType $contentType, int $start = 0, int $limit = 20, bool $parse_markdown = false, string $orderBy = 'desc'): ?ContentCollection
     {
         $feed = [];
 
-        foreach (glob($this->data_path . '/' . $route . '/*.md') as $filename) {
+        foreach (glob($this->data_path . '/' . $contentType->slug . '/*.md') as $filename) {
             $content = new Content();
             try {
                 $content->load($filename);
                 $content->parse($this->parser, $parse_markdown);
-                $content->setRoute($route);
+                $content->setRoute($contentType->slug);
                 $feed[] = $content;
             } catch (ContentNotFoundException $e) {
                 continue;

--- a/src/Provider/ContentServiceProvider.php
+++ b/src/Provider/ContentServiceProvider.php
@@ -70,7 +70,7 @@ class ContentServiceProvider implements ServiceInterface
 
         try {
             $content->load($filename);
-            $content->setRoute($request->getRoute());
+            $content->setContentType($this->getContentType($request->getRoute()));
 
             $content->parse($this->parser, $parse_markdown);
         } catch (ContentNotFoundException $e) {
@@ -100,7 +100,7 @@ class ContentServiceProvider implements ServiceInterface
                 try {
                     $content->load($filename);
                     $content->parse($this->parser, $parse_markdown);
-                    $content->setRoute($contentType->slug);
+                    $content->setContentType($contentType);
                     $list[] = $content;
                 } catch (ContentNotFoundException $e) {
                     continue;
@@ -258,7 +258,7 @@ class ContentServiceProvider implements ServiceInterface
             try {
                 $content->load($filename);
                 $content->parse($this->parser, $parse_markdown);
-                $content->setRoute($contentType->slug);
+                $content->setContentType($contentType);
                 $feed[] = $content;
             } catch (ContentNotFoundException $e) {
                 continue;

--- a/tests/Feature/ContentCollectionTest.php
+++ b/tests/Feature/ContentCollectionTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use Librarian\ContentType;
 use Minicli\App;
 use Librarian\Provider\ContentServiceProvider;
 use Librarian\ContentCollection;
@@ -53,8 +54,9 @@ it('orders content based on front matter index (index)', function () {
 it('orders content type posts based on front matter index (index)', function () {
     $app = new App($this->config);
     $app->addService('content', new ContentServiceProvider());
-
-    $posts = $app->content->fetchFrom('posts', 0, 10, false, 'index');
+    $cType = $app->content->getContentType('posts');
+    expect($cType)->toBeInstanceOf(ContentType::class);
+    $posts = $app->content->fetchFrom($cType, 0, 10, false, 'index');
 
     expect($posts->current()->frontMatterGet('title'))->toEqual("Testing Markdown Front Matter");
 });


### PR DESCRIPTION
We need to inject the content type object into views so it's possible to "know" which content type this page is based on - this will allow for customizing views depending on the content type.