### PR TITLE
Adding default required method to webcontroller

### DIFF
--- a/src/WebController.php
+++ b/src/WebController.php
@@ -76,4 +76,9 @@ abstract class WebController implements ControllerInterface
     {
         return new Response();
     }
+
+    public function required(): array
+    {
+        return [];
+    }
 }


### PR DESCRIPTION
Facilitate usage in commands by creating a default required method. The web controllers don't get any parameters so we're returning an empty array.