### PR TITLE
Implementing suppport to nested content dirs

### DIFF
--- a/src/ContentType.php
+++ b/src/ContentType.php
@@ -18,6 +18,8 @@ class ContentType
 
     public int $index = 100;
 
+    public array $children = [];
+
     /**
      * @throws Exception\ContentNotFoundException
      */

--- a/tests/Feature/ContentTest.php
+++ b/tests/Feature/ContentTest.php
@@ -38,6 +38,12 @@ it('loads content from request and parses front matter', function () {
         ->and($content->body_markdown)->toBeString();
 });
 
+it('loads nested content and parses front matter', function () {
+    $content = $this->app->content->fetch('docs/en/test0');
+    expect($content->frontMatterGet('title'))->toBe('Testing Sub-Level En')
+        ->and($content->body_markdown)->toBeString();
+});
+
 it('loads the full list of content when no limit is passed', function () {
     $content = $this->app->content->fetchAll(0, 0);
     expect($content)->toBeInstanceOf(ContentCollection::class)
@@ -48,6 +54,34 @@ it('loads tag list', function () {
     $tags = $this->app->content->fetchTagList(false);
     expect($tags)->toBeArray()
         ->and(count($tags))->toBeGreaterThan(2);
+});
+
+it('loads the right number of content types', function () {
+    $types = $this->app->content->getContentTypes();
+    expect($types)->toHaveCount(3);
+});
+
+it('loads the right number of articles in a top-level ContentType', function () {
+    $type = $this->app->content->getContentType('docs');
+    expect($type)->toBeInstanceOf(ContentType::class)
+        ->and($type->title)->toBe('Docs')
+        ->and($this->app->content->fetchFrom($type))->toHaveCount(1);
+
+});
+
+it('loads nested Content Types', function () {
+    $type = $this->app->content->getContentType('docs');
+    expect($type)->toBeInstanceOf(ContentType::class)
+        ->and($type->children)->toHaveCount(2);
+
+});
+
+it('fetches a nested content type and its posts', function () {
+    $type = $this->app->content->getContentType('docs/en');
+    expect($type)->toBeInstanceOf(ContentType::class)
+        ->and($type->title)->toBe('English Docs')
+        ->and($this->app->content->fetchFrom($type))->toHaveCount(2);
+
 });
 
 it('loads content types respecting index order', function () {

--- a/tests/resources/docs/en/_index
+++ b/tests/resources/docs/en/_index
@@ -1,0 +1,5 @@
+---
+title: English Docs
+description: English Docs section
+index: 100
+---

--- a/tests/resources/docs/en/test0.md
+++ b/tests/resources/docs/en/test0.md
@@ -1,0 +1,9 @@
+---
+title: Testing Sub-Level En
+description: Test Description
+custom: My Custom info
+tags: test, librarian
+index: 1
+---
+
+## Testing

--- a/tests/resources/docs/en/test1.md
+++ b/tests/resources/docs/en/test1.md
@@ -1,0 +1,9 @@
+---
+title: Testing Sub-Level En 02
+description: Test Description
+custom: My Custom info
+tags: test, librarian
+index: 1
+---
+
+## Testing

--- a/tests/resources/docs/pt/test0.md
+++ b/tests/resources/docs/pt/test0.md
@@ -1,0 +1,9 @@
+---
+title: Testando Sub-Level pt
+description: Test Description
+custom: My Custom info
+tags: test, librarian
+index: 1
+---
+
+## Testando

--- a/tests/resources/docs/pt/test1.md
+++ b/tests/resources/docs/pt/test1.md
@@ -1,0 +1,9 @@
+---
+title: Testando Sub-Level ppt 02
+description: Test Description
+custom: My Custom info
+tags: test, librarian
+index: 1
+---
+
+## Testando


### PR DESCRIPTION
This PR implements support to ([nested content directories](https://github.com/librarianphp/librarian/issues/53)). 

The `ContentType` class now has a `children` property that will be loaded with sub-levels of content. Added tests to verify that the content is correctly loaded within each level. Needs further testing in the application template to check that slugs / urls are functional for navigation.