### PR TITLE
Redefining request parts and updating tests

### DIFF
--- a/src/Provider/ContentServiceProvider.php
+++ b/src/Provider/ContentServiceProvider.php
@@ -56,10 +56,9 @@ class ContentServiceProvider implements ServiceInterface
 
     public function fetch(string $route, bool $parse_markdown = true): ?Content
     {
-        $request = new Request([], '/' . $route);
-        $filename = $this->data_path . '/' . $request->getRoute() . '/' . $request->getSlug() . '.md';
+        $request = new Request([], $route);
+        $filename = $this->data_path . '/' . $request->getParent() . '/' . $request->getSlug() . '.md';
         $content = new Content();
-
         try {
             $content->load($filename);
             $content->setContentType($this->getContentType($request->getRoute()));

--- a/src/Request.php
+++ b/src/Request.php
@@ -52,7 +52,7 @@ class Request
         $parts = explode('/', $this->path);
         $this->route = $parts[1];
         $this->parent = dirname($this->path);
-        $this->slug = str_replace('/' . $this->route . '/', '', $this->path);
+        $this->slug = basename($this->path);
     }
 
     public function getParams(): array

--- a/tests/Feature/RequestTest.php
+++ b/tests/Feature/RequestTest.php
@@ -41,7 +41,7 @@ it('loads content in nested structure', function () {
     $request = $this->app->router->getRequest();
     expect($request->getRoute())->toBe('docs')
         ->and($request->getParent())->toBe('/docs/en')
-        ->and($request->getSlug())->toBe('en/test0');
+        ->and($request->getSlug())->toBe('test0');
 
     $contentType = $this->app->content->getContentType($request->getParent());
     expect($contentType)->toBeInstanceOf(ContentType::class)


### PR DESCRIPTION
Fixing slug definition so it actually contains only the post slug. Updated tests accordingly. Will need some updates in `librarianphp/command-web` controllers to adjust to the new structure.